### PR TITLE
fix #229

### DIFF
--- a/content/manage-addons.js
+++ b/content/manage-addons.js
@@ -71,7 +71,7 @@ var stylishManageAddons = {
 stylishManageAddons._createItem = createItem,
 createItem = function(o, aIsInstall, aIsRemote) {
 	var item = stylishManageAddons._createItem(o, aIsInstall, aIsRemote);
-	if (item.mAddon.type == "userstyle") {
+	if ("mAddon" in item && item.mAddon.type == "userstyle") {
 		item.setAttribute("styleTypes", item.mAddon.styleTypes);
 		item.setAttribute("reportable", item.mAddon.style.idUrl == null ? false : (item.mAddon.style.idUrl.indexOf("http://userstyles.org/") == 0));
 	}


### PR DESCRIPTION
I did not find the reasons, just found [this](https://hg.mozilla.org/mozilla-central/annotate/56f5ffd44b7f13d5db5bd497018f428dcbb28fc4/browser/base/content/test/social/browser_social_activation.js#l102).

This fix a critical error: `item.mAddon is undefined manage-addons.js:74:0`