### PR TITLE
switch some url to https and enhanced `reportable` resilience

### DIFF
--- a/content/urls.properties
+++ b/content/urls.properties
@@ -1,2 +1,2 @@
-findstylesforthissiteurl=http://userstyles.org/styles/search/%S
-firstrun=http://userstyles.org/firstrun
+findstylesforthissiteurl=https://userstyles.org/styles/search/%S
+firstrun=https://userstyles.org/firstrun


### PR DESCRIPTION
This is a partial solution to #237, the still need to remove the suspect through local peeling.

I adjusted the way of determine `reportable`, I know it seems from an internal URL (like "http://userstyles.org/styles/89541") and works fine, but I guess the need to plan ahead.