### PR TITLE
Enable strict mode and fix warnings

### DIFF
--- a/components/aboutStylishEdit.js
+++ b/components/aboutStylishEdit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 

--- a/components/stylishCommandLine.js
+++ b/components/stylishCommandLine.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 function StylishCommandLine() {}

--- a/components/stylishDataSource.js
+++ b/components/stylishDataSource.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 function StylishDataSource() {}

--- a/components/stylishStartup.js
+++ b/components/stylishStartup.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 try {
 	Components.utils.import("resource://gre/modules/AddonManager.jsm");
@@ -368,7 +370,7 @@ observerService.addObserver(addonsObserver, "stylish-style-delete", false);
 Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).QueryInterface(Components.interfaces.nsIPrefBranch).addObserver("extensions.stylish.styleRegistrationEnabled", turnOnOffObserver, false);
 
 function wireUpMessaging() {
-	Components.utils.import("chrome://stylish/content/common.js", this);
+	Components.utils.import("chrome://stylish/content/common.js");
 	var service = Components.classes["@userstyles.org/style;1"].getService(Components.interfaces.stylishStyle);
 	var STRINGS = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService).createBundle("chrome://stylish/locale/overlay.properties");
 

--- a/components/stylishStyle.js
+++ b/components/stylishStyle.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 
 function Style() {
@@ -136,7 +138,7 @@ Style.prototype = {
 		// everything up to the first regex character
 		var re = /[\.\(\)\[\]]/g;
 		var match;
-		while (match = re.exec(r)) {
+		while ((match = re.exec(r)) !== null) {
 			if (r[match.index - 1] != "\\") {
 				break;
 			}
@@ -461,7 +463,7 @@ Style.prototype = {
 
 		//if we have a url for a hash, use that
 		if (this.md5Url) {
-			function handleMd5(text) {
+			var handleMd5 = function (text) {
 				if (text.length != 32) {
 					Components.utils.reportError("Could not update '" + that.name + "' - '" + that.md5Url + "' did not return a md5 hash.");
 					notifyDone("no-update-available");
@@ -474,7 +476,7 @@ Style.prototype = {
 			this.download(this.md5Url, handleMd5, handleFailure);
 		//otherwise use the update URL which makes us download the full code
 		} else if (this.updateUrl) {
-			function handleUpdateUrl(text, contentType) {
+			var handleUpdateUrl = function (text, contentType) {
 				if (contentType != "text/css") {
 					Components.utils.reportError("Could not update '" + that.name + "' - '" + that.updateUrl + "' returned content type '" + contentType + "'.");
 					notifyDone("no-update-available");
@@ -800,12 +802,12 @@ Style.prototype = {
 			closeConnection = true;
 		}
 		var statement = connection.createStatement(sql);
-		for (i in parameters) {
+		for (var i in parameters) {
 			this.bind(statement, i, parameters[i]);
 		}
 		try {
 			var that = this;
-			function e(name) {
+			var e = function (name) {
 				return that.extract(statement, name);
 			};
 			var styles = [];

--- a/content/base-test.js
+++ b/content/base-test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 var Style = Components.classes["@userstyles.org/style;1"].getService(Components.interfaces.stylishStyle);
 var observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);

--- a/content/clear.js
+++ b/content/clear.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).QueryInterface(Components.interfaces.nsIPrefBranch);
 if (!prefService.getBoolPref("extensions.stylish.promptOnClear") || confirm("Are you sure you want to delete all Stylish styles?")) {
 	var service = Components.classes["@userstyles.org/style;1"].getService(Components.interfaces.stylishStyle);

--- a/content/common.js
+++ b/content/common.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var EXPORTED_SYMBOLS = ["stylishCommon"];
 
 var stylishCommon = {
@@ -95,7 +97,7 @@ var stylishCommon = {
 		}
 		var url = "about:stylish-edit";
 		var first = true;
-		for (i in params) {
+		for (var i in params) {
 			if (params[i]) {
 				url += (first ? "?" : "&") + encodeURIComponent(i) + "=" + encodeURIComponent(params[i])
 			}

--- a/content/domiOverlay.js
+++ b/content/domiOverlay.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var stylishDomi = {
 
 	init: function() {

--- a/content/edit.js
+++ b/content/edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 Components.utils.import("resource://gre/modules/Services.jsm");
 var require = null;
@@ -129,6 +131,7 @@ function initStyle() {
 	var code = null;
 	var urlParts = location.href.split("?");
 	if (urlParts.length > 1) {
+        let params;
 		params = urlParts[1].split("&");
 		params.forEach(function(param) {
 			var kv = param.split("=");
@@ -306,12 +309,12 @@ function checkForErrors() {
 				
 				// ignore other crap
 				if (error.category == "CSS Parser" && error.sourceName == "about:blank") {
-					var message = error.lineNumber + ":" + error.columnNumber + " " + error.errorMessage;
+					var newmessage = error.lineNumber + ":" + error.columnNumber + " " + error.errorMessage;
 					// don't duplicate
-					if (currentMessages.indexOf(message) == -1) {
-						currentMessages.push(message);
+					if (currentMessages.indexOf(newmessage) == -1) {
+						currentMessages.push(newmessage);
 						var label = document.createElementNS(stylishCommon.XULNS, "label");
-						label.appendChild(document.createTextNode(message));
+						label.appendChild(document.createTextNode(newmessage));
 						label.addEventListener("click", function() {goToLine(error.lineNumber, error.columnNumber) }, false);
 						errors.appendChild(label);
 					}
@@ -404,7 +407,7 @@ function insertDataURI() {
 	var file = fp.file;
 	var contentType = cc["@mozilla.org/mime;1"].getService(ci.nsIMIMEService).getTypeFromFile(file);
 	var inputStream = cc["@mozilla.org/network/file-input-stream;1"].createInstance(ci.nsIFileInputStream);
-	inputStream.init(file, 0x01, 0600, 0);
+	inputStream.init(file, parseInt("01", 16), parseInt("0600", 8), 0);
 	var stream = cc["@mozilla.org/binaryinputstream;1"].createInstance(ci.nsIBinaryInputStream);
 	stream.setInputStream(inputStream);
 	var encoded = btoa(stream.readBytes(stream.available()));

--- a/content/frame-utils.js
+++ b/content/frame-utils.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var EXPORTED_SYMBOLS = ["stylishFrameUtils"];
 
 /* Functions to be used by both frame and chrome scripts */

--- a/content/install-frame-script.js
+++ b/content/install-frame-script.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Components.utils.import("chrome://stylish/content/frame-utils.js", this);
 
 function isAllowedToInstall(doc) {

--- a/content/install.js
+++ b/content/install.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var style, strings, nameElement;
 var installPingURL = null;
 var installCallback = null;

--- a/content/manage-addons.js
+++ b/content/manage-addons.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var stylishManageAddons = {
 
 	getSortButtons: function() {

--- a/content/overlay.js
+++ b/content/overlay.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var stylishOverlay = {
 	service: Components.classes["@userstyles.org/style;1"].getService(Components.interfaces.stylishStyle),
 	styleMenuItemTemplate: null,

--- a/content/unittest.js
+++ b/content/unittest.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function AssertionFailure(message) {
 	this.message = message;
 }


### PR DESCRIPTION
This is experimental for #211, I can not guarantee that everything is good, but looks works fine.

Doubts:
* I got two blue fail on `chrome://stylish/content/test.xul`, but looks same for the current version.
* I'm not sure where it should add a `"use strict";` marker, so added to all js files.
* The `Components.utils.import("chrome://stylish/content/common.js", this);` will throw an error in strict mode, unless remove the `this`. I don't understand it and don‘t know what impact this will.

TODO:
* Maybe we should replace a lot of `var` to `let` or `const`, this will make the code more clear.
* The code has a lot of tab characters, I hope you to use more common / standard spaces characters.