### PR TITLE
Remove BrowserToolboxCustomizeDone(true);

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -28,11 +28,6 @@ var stylishOverlay = {
 					navbar.currentSet = newCurrentSet; // for immediate display
 					navbar.setAttribute("currentset", newCurrentSet); // for persisting
 					document.persist(navbar.id, "currentset");
-					try {
-						BrowserToolboxCustomizeDone(true);
-					} catch (e) {
-						Components.utils.reportError(e);
-					}
 				}
 				prefService.setIntPref("extensions.stylish.firstRun", 3);
 		}


### PR DESCRIPTION
I did not find it's necessity, it is now only exists in esr24, gCustomizeMode.exit() perhaps its successor.
Trigge it when extensions.stylish.firstRun = 2 and restart.
toolbutton added fine even without it on esr24.8.1.