### PR TITLE
Remove a overrideMimeType to fix two error on test.xul

### DIFF
--- a/components/stylishStyle.js
+++ b/components/stylishStyle.js
@@ -965,7 +965,6 @@ Style.prototype = {
 		}, false);
 		// QI it to nsIXMLHttpRequest to open and send the request:
 		request.QueryInterface(Components.interfaces.nsIXMLHttpRequest);
-		request.overrideMimeType("text/plain");
 		try {
 			// this can fail if URL is malformed
 			request.open("GET", url, true);


### PR DESCRIPTION
Just an intention, I'm not sure it's consequences.

The `chrome://stylish/content/test.xul` has been broken after 8e8aa434edfdfe46b8aeae0e5c0e35132907949a, with two blue warnings:
```
asyncRunUpdateAvailable Expected 'update-success', got 'update-failure'.
asyncUpdateUrlWithUpdate Expected 'update-available', got 'no-update-available'.
```
and warnings in Browser Console:
```
Could not update 'Unit test testRunUpdateAvailable' - 'data:text/css,* {color: red}' returned content type 'text/plain'. stylishStyle.js:513:0
Could not update 'testUpdateUrlWithUpdate' - 'data:text/css,* { color: red}' returned content type 'text/plain'. stylishStyle.js:481:0
Could not update 'testUpdateUrlNoUpdate' - 'data:text/css,* {color: blue}' returned content type 'text/plain'. stylishStyle.js:481:0
```
Occurred in:
```
		function handleSuccess(code, contentType) {
			if (contentType != "text/css") {
```
```
		} else if (this.updateUrl) {
			var handleUpdateUrl = function (text, contentType) {
				if (contentType != "text/css") {
```

The patch fixes the `test.xul` to all green, and seems works well.
The overrideMimeType lack of intent description.