### PR TITLE
Fix bad array concatenation -> string cast

### DIFF
--- a/components/stylishStyle.js
+++ b/components/stylishStyle.js
@@ -438,11 +438,11 @@ Style.prototype = {
 		function toHexString(charCode) {
 			return ("0" + charCode.toString(16)).slice(-2);
 		}
-		var res = [];
+		var res = "";
 		for (var i in hash) {
 			res += toHexString(hash.charCodeAt(i));
 		}
-		return res.join("");
+		return res;
 	},
 
 	checkForUpdates: function(observer) {


### PR DESCRIPTION
Really stupid mistake in d402de3. Concatenated instead of pushed to an array and caused an error when joining on return. 

[Supposedly breaks style updates?](https://github.com/JasonBarnabe/stylish/pull/265#commitcomment-15535224) Couldn't reproduce and I'm not actually sure what code path triggers it. It's obviously broken code, in any case.